### PR TITLE
Allow env variables to be given

### DIFF
--- a/caddy/config.json
+++ b/caddy/config.json
@@ -1,6 +1,6 @@
 {
     "name": "Caddy",
-    "version": "1.5",
+    "version": "1.6",
     "slug": "caddy",
     "description": "Caddy web server",
     "url": "https://github.com/korylprince/hassio-caddy/tree/master/caddy",
@@ -10,9 +10,11 @@
     "map": ["share", "ssl:rw"],
     "host_network": true,
     "options": {
-        "flags": []
+        "flags": [],
+        "env_vars": []
     },
     "schema": {
-        "flags": ["str"]
+        "flags": ["str"],
+        "env_vars": ["str"]
     }
 }

--- a/caddy/run.sh
+++ b/caddy/run.sh
@@ -6,8 +6,7 @@ CADDY_SHARE_PATH="/share/caddy"
 CADDY_PATH=/usr/sbin/caddy
 
 ARGS=( "-conf" "$CADDY_SHARE_PATH/Caddyfile" $(jq --raw-output '.flags[]' $CONFIG_PATH) )
-
-echo "Running Caddy with arguments: ${ARGS[*]}"
+ENV_VARS=$(jq --raw-output '.env_vars[]' $CONFIG_PATH)
 
 if [ -f "$CADDY_SHARE_PATH/caddy.bin" ]; then
     CADDY_PATH="$CADDY_SHARE_PATH/caddy.bin"
@@ -16,4 +15,6 @@ else
     echo "Using built-in Caddy: $($CADDY_PATH -version)"
 fi
 
-exec $CADDY_PATH ${ARGS[*]}
+echo "Running Caddy: exec env ${ENV_VARS[*]} $CADDY_PATH ${ARGS[*]}"
+
+exec env ${ENV_VARS[*]} $CADDY_PATH ${ARGS[*]}


### PR DESCRIPTION
I'm using Cloudflare TLS plugin with Caddy, which requires API keys given as environment variables. As far as I can tell, you are not able to do that currently. Thus, I added this simple feature using the existing conventions with `flags`.

I did test this in my fork, and I was successful in my attempts to use Cloudflare plugin. Obviously this commit does not directly work as a Docker hub does not contain image for version 1.6 (for my tests, I used locally built image instead of prebuilt one).

Tell me what you think.